### PR TITLE
Remove whitespace

### DIFF
--- a/root/plugin.php
+++ b/root/plugin.php
@@ -8,9 +8,7 @@
  * Author URI:  {%= author_url %}
  * License:     GPLv2+
  */
-?>
 
-<?php
 /** 
  * Copyright {%= grunt.template.today('yyyy') %}  {%= author_name %}  (email : {%= author_email %})
  * 
@@ -68,4 +66,3 @@ add_action( 'init', '{%= prefix %}_init' );
 // Wireup filters
 
 // Wireup shortcodes
-?>


### PR DESCRIPTION
Removes whitespace and the closing php tag to prevent 'headers already sent' notices.
