### PR TITLE
Changed from git@ to https:// in instructions for cloning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Once grunt-init is installed, place this template in your `~/.grunt-init/` direc
 ### Linux/Mac Users
 
 ```
-git clone git@github.com:10up/grunt-wp-plugin.git ~/.grunt-init/wp-plugin
+git clone https://github.com/10up/grunt-wp-plugin ~/.grunt-init/wp-plugin
 ```
 
 ### Windows Users
 
 ```
-git clone git@github.com:10up/grunt-wp-plugin.git %USERPROFILE%/.grunt-init/wp-plugin
+git clone https://github.com/10up/grunt-wp-plugin %USERPROFILE%/.grunt-init/wp-plugin
 ```
 
 ## Usage


### PR DESCRIPTION
Using git@github.com:10up/grunt-wp-plugin.git didn't work for me as it required authentication. On the other hand git clone https://github.com/10up/grunt-wp-plugin ~/.grunt-init/wp-plugin worked fine.