### PR TITLE
Prevent Git from trying to track artifacts in .sass-cache/

### DIFF
--- a/root/.gitignore
+++ b/root/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 release
+.sass-cache


### PR DESCRIPTION
There isn't a good reason for .sass-cache to get committed to the repo, so let's keep it out!