### PR TITLE
Bump requires/tested to version number for core

### DIFF
--- a/root/readme.txt
+++ b/root/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      10up
 Donate link:       {%= homepage %}
 Tags: 
-Requires at least: 3.9
-Tested up to:      3.9
+Requires at least: 4.1
+Tested up to:      4.1
 Stable tag:        0.1.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Bumping it to 4.1
